### PR TITLE
Added findByXXX methods in LessonDAO interface + implementation + changed inclusive to exclusive

### DIFF
--- a/src/main/java/tennisclub/dao/LessonDao.java
+++ b/src/main/java/tennisclub/dao/LessonDao.java
@@ -72,10 +72,10 @@ public interface LessonDao {
 
     /**
      * Finds all Lessons that at least partially take place
-     * during the specified time interval. The interval is inclusive.
+     * during the specified time interval. The interval is exclusive.
      *
      * More formally, retrieve all Lessons l such that:
-     *     l.startTime <= to && l.endTime >= from
+     *     l.startTime < to && l.endTime > from
      *
      * The behaviour of this method is undefined if:
      *     from > to

--- a/src/main/java/tennisclub/dao/LessonDao.java
+++ b/src/main/java/tennisclub/dao/LessonDao.java
@@ -1,8 +1,11 @@
 package tennisclub.dao;
 
+import tennisclub.entity.Court;
+import tennisclub.entity.Event;
 import tennisclub.entity.Lesson;
 import tennisclub.entity.enums.Level;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -45,6 +48,43 @@ public interface LessonDao {
     Lesson findById(Long id);
 
     //List<Lesson> findByLecturerName(String lecturerName);
+
+    /**
+     * Finds all Lessons taking place on the specified court.
+     * @param court on which the Lessons take place
+     * @return all Lessons taking place on the given court
+     */
+    List<Lesson> findByCourt(Court court);
+
+    /**
+     * Finds all Lessons starting at the specified time.
+     * @param startTime at which the Lessons start
+     * @return all Lessons starting at the given time
+     */
+    List<Lesson> findByStartTime(LocalDateTime startTime);
+
+    /**
+     * Finds all Lessons ending at the specified time.
+     * @param endTime at which the Lessons end
+     * @return all Lessons ending at the given time
+     */
+    List<Lesson> findByEndTime(LocalDateTime endTime);
+
+    /**
+     * Finds all Lessons that at least partially take place
+     * during the specified time interval. The interval is inclusive.
+     *
+     * More formally, retrieve all Lessons l such that:
+     *     l.startTime <= to && l.endTime >= from
+     *
+     * The behaviour of this method is undefined if:
+     *     from > to
+     *
+     * @param from the beginning of the interval
+     * @param to the end of the interval
+     * @return all Lessons whose time falls into the interval
+     */
+    List<Lesson> findByTimeInterval(LocalDateTime from, LocalDateTime to);
 
     /**
      * Finds all Lessons with particular capacity.

--- a/src/main/java/tennisclub/dao/LessonDaoImpl.java
+++ b/src/main/java/tennisclub/dao/LessonDaoImpl.java
@@ -1,12 +1,15 @@
 package tennisclub.dao;
 
 import org.springframework.stereotype.Repository;
+import tennisclub.entity.Court;
+import tennisclub.entity.Event;
 import tennisclub.entity.Lesson;
 import tennisclub.entity.enums.Level;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -47,6 +50,35 @@ public class LessonDaoImpl implements LessonDao{
     public List<Lesson> findByLecturerName(String lecturerName) {
         return null;
     }*/
+
+    @Override
+    public List<Lesson> findByCourt(Court court) {
+        return em.createQuery("select l from Lesson l where l.court = :court", Lesson.class)
+                .setParameter("court", court)
+                .getResultList();
+    }
+
+    @Override
+    public List<Lesson> findByStartTime(LocalDateTime startTime) {
+        return em.createQuery("select l from Lesson l where l.startTime = :startTime", Lesson.class)
+                .setParameter("startTime", startTime)
+                .getResultList();
+    }
+
+    @Override
+    public List<Lesson> findByEndTime(LocalDateTime endTime) {
+        return em.createQuery("select l from Lesson l where l.endTime = :endTime", Lesson.class)
+                .setParameter("endTime", endTime)
+                .getResultList();
+    }
+
+    @Override
+    public List<Lesson> findByTimeInterval(LocalDateTime from, LocalDateTime to) {
+        return em.createQuery("select l from Lesson l where l.endTime >= :from and l.startTime <= :to", Lesson.class)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getResultList();
+    }
 
     @Override
     public List<Lesson> findByCapacity(Integer capacity) {

--- a/src/main/java/tennisclub/dao/LessonDaoImpl.java
+++ b/src/main/java/tennisclub/dao/LessonDaoImpl.java
@@ -74,7 +74,7 @@ public class LessonDaoImpl implements LessonDao{
 
     @Override
     public List<Lesson> findByTimeInterval(LocalDateTime from, LocalDateTime to) {
-        return em.createQuery("select l from Lesson l where l.endTime >= :from and l.startTime <= :to", Lesson.class)
+        return em.createQuery("select l from Lesson l where l.endTime > :from and l.startTime < :to", Lesson.class)
                 .setParameter("from", from)
                 .setParameter("to", to)
                 .getResultList();


### PR DESCRIPTION
The added methods are the ones present in the EventDAO interface, therefore:
- find by court
- find by start time
- find by end time
- find by time interval

Also in the last commit, changed the inclusive interval to exclusive to match Mira's `Event` class.