### PR TITLE
Added findByXXX methods in TournamentDAO interface + implementation + changed inclusive to exclusive

### DIFF
--- a/src/main/java/tennisclub/dao/TournamentDao.java
+++ b/src/main/java/tennisclub/dao/TournamentDao.java
@@ -69,10 +69,10 @@ public interface TournamentDao {
 
     /**
      * Finds all Tournaments that at least partially take place
-     * during the specified time interval. The interval is inclusive.
+     * during the specified time interval. The interval is exclusive.
      *
      * More formally, retrieve all Tournaments t such that:
-     *     t.startTime <= to && t.endTime >= from
+     *     t.startTime < to && t.endTime > from
      *
      * The behaviour of this method is undefined if:
      *     from > to

--- a/src/main/java/tennisclub/dao/TournamentDao.java
+++ b/src/main/java/tennisclub/dao/TournamentDao.java
@@ -1,7 +1,10 @@
 package tennisclub.dao;
 
+import tennisclub.entity.Court;
+import tennisclub.entity.Event;
 import tennisclub.entity.Tournament;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -42,6 +45,43 @@ public interface TournamentDao {
      * @return a Tournament whose id matches the given id
      */
     Tournament findById(Long id);
+
+    /**
+     * Finds all Tournaments taking place on the specified court.
+     * @param court on which the Tournaments take place
+     * @return all Tournaments taking place on the given court
+     */
+    List<Tournament> findByCourt(Court court);
+
+    /**
+     * Finds all Tournaments starting at the specified time.
+     * @param startTime at which the Tournaments start
+     * @return all Tournaments starting at the given time
+     */
+    List<Tournament> findByStartTime(LocalDateTime startTime);
+
+    /**
+     * Finds all Tournaments ending at the specified time.
+     * @param endTime at which the Tournaments end
+     * @return all Tournaments ending at the given time
+     */
+    List<Tournament> findByEndTime(LocalDateTime endTime);
+
+    /**
+     * Finds all Tournaments that at least partially take place
+     * during the specified time interval. The interval is inclusive.
+     *
+     * More formally, retrieve all Tournaments t such that:
+     *     t.startTime <= to && t.endTime >= from
+     *
+     * The behaviour of this method is undefined if:
+     *     from > to
+     *
+     * @param from the beginning of the interval
+     * @param to the end of the interval
+     * @return all Tournaments whose time falls into the interval
+     */
+    List<Tournament> findByTimeInterval(LocalDateTime from, LocalDateTime to);
 
     /**
      * Finds all Tournaments with particular capacity.

--- a/src/main/java/tennisclub/dao/TournamentDaoImpl.java
+++ b/src/main/java/tennisclub/dao/TournamentDaoImpl.java
@@ -71,7 +71,7 @@ public class TournamentDaoImpl implements TournamentDao {
 
     @Override
     public List<Tournament> findByTimeInterval(LocalDateTime from, LocalDateTime to) {
-        return em.createQuery("select t from Tournament t where t.endTime >= :from and t.startTime <= :to", Tournament.class)
+        return em.createQuery("select t from Tournament t where t.endTime > :from and t.startTime < :to", Tournament.class)
                 .setParameter("from", from)
                 .setParameter("to", to)
                 .getResultList();

--- a/src/main/java/tennisclub/dao/TournamentDaoImpl.java
+++ b/src/main/java/tennisclub/dao/TournamentDaoImpl.java
@@ -1,11 +1,14 @@
 package tennisclub.dao;
 
 import org.springframework.stereotype.Repository;
+import tennisclub.entity.Court;
+import tennisclub.entity.Event;
 import tennisclub.entity.Tournament;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -43,6 +46,35 @@ public class TournamentDaoImpl implements TournamentDao {
     @Override
     public Tournament findById(Long id) {
         return em.find(Tournament.class, id);
+    }
+
+    @Override
+    public List<Tournament> findByCourt(Court court) {
+        return em.createQuery("select t from Tournament t where t.court = :court", Tournament.class)
+                .setParameter("court", court)
+                .getResultList();
+    }
+
+    @Override
+    public List<Tournament> findByStartTime(LocalDateTime startTime) {
+        return em.createQuery("select t from Tournament t where t.startTime = :startTime", Tournament.class)
+                .setParameter("startTime", startTime)
+                .getResultList();
+    }
+
+    @Override
+    public List<Tournament> findByEndTime(LocalDateTime endTime) {
+        return em.createQuery("select t from Tournament t where t.endTime = :endTime", Tournament.class)
+                .setParameter("endTime", endTime)
+                .getResultList();
+    }
+
+    @Override
+    public List<Tournament> findByTimeInterval(LocalDateTime from, LocalDateTime to) {
+        return em.createQuery("select t from Tournament t where t.endTime >= :from and t.startTime <= :to", Tournament.class)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getResultList();
     }
 
     @Override


### PR DESCRIPTION
The added methods are the ones present in the EventDAO interface, therefore:
- find by court
- find by start time
- find by end time
- find by time interval

Also in the last commit, changed the inclusive interval to exclusive to match Mira's `Event` class.