### PR TITLE
Sample data correct admin

### DIFF
--- a/sample-data/src/main/java/tennisclub/sampledata/SampleDataLoader.java
+++ b/sample-data/src/main/java/tennisclub/sampledata/SampleDataLoader.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+import tennisclub.dao.UserDao;
 import tennisclub.entity.*;
 import tennisclub.enums.CourtType;
 import tennisclub.enums.Level;
@@ -19,6 +20,7 @@ import java.util.List;
 @Component
 public class SampleDataLoader implements ApplicationRunner {
     private final UserService userService;
+    private final UserDao userDao;
     private final CourtService courtService;
     private final BookingService bookingService;
     private final LessonService lessonService;
@@ -28,12 +30,14 @@ public class SampleDataLoader implements ApplicationRunner {
 
     @Autowired
     public SampleDataLoader(UserService userService,
+                            UserDao userDao,
                             CourtService courtService,
                             BookingService bookingService,
                             LessonService lessonService,
                             TournamentService tournamentService,
                             TimeService timeService) {
         this.userService = userService;
+        this.userDao = userDao;
         this.courtService = courtService;
         this.bookingService = bookingService;
         this.lessonService = lessonService;
@@ -52,6 +56,8 @@ public class SampleDataLoader implements ApplicationRunner {
         User user2 = persistUser("Mark Tennisy", "TennisDevil666", "password", "mark@gmail.com", Role.USER);
         User user3 = persistUser("Lucy Fast", "lussy", "passwod", "lucy@gmail.com", Role.USER);
         User admin = persistUser("Admin Adminy", "admin", "admin", "admin@gmail.com", Role.MANAGER);
+        admin.setRole(Role.MANAGER);
+        userDao.update(admin);
 
         Court court1 = persistCourt("Pretty nice court", "Brno, Czech Republic", CourtType.GRASS);
         Court court2 = persistCourt("Courty court", "Prague, Czech Republic", CourtType.TURF);

--- a/sample-data/src/main/java/tennisclub/sampledata/SampleDataLoader.java
+++ b/sample-data/src/main/java/tennisclub/sampledata/SampleDataLoader.java
@@ -52,12 +52,12 @@ public class SampleDataLoader implements ApplicationRunner {
     }
 
     public void loadData() {
-        User user1 = persistUser("Bob Smith", "Bobby123", "password", "bob@gmail.com", Role.USER);
-        User user2 = persistUser("Mark Tennisy", "TennisDevil666", "password", "mark@gmail.com", Role.USER);
-        User user3 = persistUser("Lucy Fast", "lussy", "passwod", "lucy@gmail.com", Role.USER);
         User admin = persistUser("Admin Adminy", "admin", "admin", "admin@gmail.com", Role.MANAGER);
         admin.setRole(Role.MANAGER);
         userDao.update(admin);
+        User user1 = persistUser("Bob Smith", "Bobby123", "password", "bob@gmail.com", Role.USER);
+        User user2 = persistUser("Mark Tennisy", "TennisDevil666", "password", "mark@gmail.com", Role.USER);
+        User user3 = persistUser("Lucy Fast", "lussy", "passwod", "lucy@gmail.com", Role.USER);
 
         Court court1 = persistCourt("Pretty nice court", "Brno, Czech Republic", CourtType.GRASS);
         Court court2 = persistCourt("Courty court", "Prague, Czech Republic", CourtType.TURF);


### PR DESCRIPTION
Hey, the sample admin used to have role USER. This was due to the fact he was created via the UserService, which (as a security measure, we don't expect adding any new managers, let's call it a feature :D ) prevents creating any users with the role MANAGER. The problem is that creating the users using UserDao does not generate the password hashes, therefore any manager has to be first created via the UserService, then have the role changed and after that propagate the change via UserDao. Now it works as it should :)

I also moved the admin to be created first so it has id = 1 (just a cosmetic change).